### PR TITLE
Adds styling to textarea in json-form-editor

### DIFF
--- a/samples/json-form-editor/src/json-editor-contentful-theme.js
+++ b/samples/json-form-editor/src/json-editor-contentful-theme.js
@@ -34,6 +34,7 @@ JSONEditor.defaults.themes.contentful = (function (JSONEditor) {
     }),
     getHeaderButtonHolder: 'jfe-button-holder',
     getSelectInput: 'cf-form-input',
+    getTextareaInput: 'cf-form-input',
     getSwitcher: function (options) {
       var el = this.getSelectInput(options);
       el.className += ' jfe-switcher';


### PR DESCRIPTION
Simply adds the `cf-form-input` class to `<textarea />` elements so you get Contentful's styles.