### PR TITLE
Fix Extentions API link in README.md

### DIFF
--- a/samples/rating-dropdown/README.md
+++ b/samples/rating-dropdown/README.md
@@ -105,7 +105,7 @@ contentful-extension update --space-id MY_SPACE_ID --force
 ~~~
 
 You can go on from here by having a look at the
-[UI Extensions API documentation](ui-ext-api-doc) documentation.
+[UI Extensions API documentation](https://github.com/contentful/ui-extensions-sdk/blob/master/docs/ui-extensions-sdk-frontend.md) documentation.
 
 
 [static-one-liners]: https://gist.github.com/willurd/5720255


### PR DESCRIPTION
When I installed the extension, I was getting this error:
```Cannot read the file defined as the "srcdoc" property (/Users/christinewang/Documents/Coding/extensions-master/samples/youtube-id/dist/index.html).```

There appears to be an error in the file path and it worked when I removed the dist path.