### PR TITLE
fix(inbound-references): remove invalid complex field types

### DIFF
--- a/samples/inbound-references/extension.json
+++ b/samples/inbound-references/extension.json
@@ -3,5 +3,5 @@
   "name": "Inbound references sidebar",
   "srcdoc": "./app.html",
   "sidebar": true,
-  "fieldTypes": ["Array", "Boolean", "Date", "Integer", "Number", "Object", "Symbol", "Link", "Location", "Text"]
+  "fieldTypes": ["Boolean", "Date", "Integer", "Number", "Object", "Symbol", "Location", "Text"]
 }


### PR DESCRIPTION
Array and Link need further configuration options. For simplicity I'd just remove them from the field types.