### PR TITLE
Fix: Spread FormInputClassList when adding to node

### DIFF
--- a/core-field-editors/src/textarea/index.js
+++ b/core-field-editors/src/textarea/index.js
@@ -11,7 +11,7 @@ export default function create (api, opts = {}) {
   const document = opts.document || window.document
 
   const textarea = document.createElement('textarea')
-  textarea.classList.add(FormInputClassList)
+  textarea.classList.add(...FormInputClassList)
   const field = api.field
   const updateInput = createUpdater(textarea, document)
 


### PR DESCRIPTION
Necessary to properly delegate the class list to the `textarea` as separated props.

## Before:

```html
<textarea class="cf-form-input,x--directed"></textarea>
```

## After:

```html
<textarea class="cf-form-input x--directed"></textarea>
```

Fixes https://github.com/contentful/extensions/pull/39.