### PR TITLE
Slug Gen - Use entry title for title field

### DIFF
--- a/samples/slug/index.html
+++ b/samples/slug/index.html
@@ -20,7 +20,8 @@ var cfExt = window.contentfulExtension || window.contentfulWidget
 
 cfExt.init(function (api) {
   var slugField = api.field
-  var titleField = api.entry.fields.title
+  var titleFieldName = api.contentType.displayField
+  var titleField = api.entry.fields[titleFieldName]
 
   var _ = window._
   var getSlug = window.getSlug


### PR DESCRIPTION
Rather than using a set name field (title) to generate slugs from, they will be generated from the entry title field. Closes issue: https://github.com/contentful/extensions/issues/63#issue-338697167