### PR TITLE
Collect coverage information about Marketplace extensions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,10 +1,13 @@
-version: 2
+version: 2.1
 
 docker: &docker
   - image: circleci/node:10.15.3
 
 cache-key: &cache-key
   key: dependency-cache-primary-{{ arch }}-{{ checksum ".nvmrc" }}-{{ checksum "package-lock.json" }}
+
+orbs:
+  codecov: codecov/codecov@1.0.4
 
 jobs:
   build:
@@ -30,7 +33,7 @@ jobs:
           command: npm run lint
       - run:
           name: Running unit tests
-          command: npm run test
+          command: npm run coverage
       - run:
           name: Building extension code
           command: npm run build
@@ -38,6 +41,9 @@ jobs:
           root: .
           paths:
             - ./dist
+      - codecov/upload:
+          file: marketplace/*/coverage/*.json
+          flags: extensions
   deploy:
     docker: *docker
     steps:

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,3 @@
+parsers:
+  javascript:
+    enable_partials: yes


### PR DESCRIPTION
Since the marketplace directory is for production quality code, let's add some subtle (or not so subtle) social pressure to add tests for them. I won't enable the check to enforce code coverage not decreasing, but making the current coverage visible seems helpful.