### PR TITLE
Set CORS and HSTS headers for hosted extensions

### DIFF
--- a/marketplace/bynder-dialog/package-lock.json
+++ b/marketplace/bynder-dialog/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bynder-dialog",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -23,6 +23,20 @@ async function writeExtensionManifest(extensionDir, manifest) {
   return makeDir(outPutDir).then(() => writeFile(filePath, JSON.stringify(manifest), 'utf8'));
 }
 
+async function writeExtensionHeaders(extensionDir) {
+  const outPutDir = path.join(BUILD_DIR, extensionDir);
+  const filePath = path.join(outPutDir, '_headers');
+
+  const headers = `/*
+  Strict-Transport-Security: max-age=300
+/extension.json
+  Access-Control-Allow-Origin: *
+  Strict-Transport-Security: max-age=300
+`;
+
+  return makeDir(outPutDir).then(() => writeFile(filePath, headers, 'utf8'));
+}
+
 dirs(`${__dirname}/../marketplace`)
   .then(extensions => {
     return Promise.all(
@@ -58,6 +72,7 @@ dirs(`${__dirname}/../marketplace`)
 
         return cpy(path.join(BASE_DIR, extension.name, 'build'), path.join(BUILD_DIR, extensionDir))
           .then(() => writeExtensionManifest(extensionDir, newManifest))
+          .then(() => writeExtensionHeaders(extensionDir))
           .then(() =>
             rename(
               path.join(BUILD_DIR, extensionDir, 'index.html'),


### PR DESCRIPTION
CORS is necessary to allow installation through the web app.

Sets a very conservative value for HSTS so we roll it back if necessary.