### PR TITLE
Fix multiline editor

### DIFF
--- a/samples/ace-editor/app.html
+++ b/samples/ace-editor/app.html
@@ -54,7 +54,7 @@
 
         // Get the field value from the UI Extension SDK
         var value = api.field.getValue() || ''
-        document.getElementById('editor').innerText = value
+        document.getElementById('editor').textContent = value
 
         // Configure Ace editor
         var editor = ace.edit('editor')


### PR DESCRIPTION
Ace editor could not correctly display multi-line text.
Value was set to innerText property, which works incorrectly with new line character "\n" in modern browsers.
Switching from innerText to textContent fixed the issue.