### PR TITLE
Adding targetOrigin logic for Safari

### DIFF
--- a/marketplace/optimizely/src/index.js
+++ b/marketplace/optimizely/src/index.js
@@ -33,7 +33,7 @@ if (window.location.hash) {
   const { access_token = null, expires_in = null } = parseHash(window.location.hash);
   const expireTime = getTokenExpirationTime(expires_in);
 
-  window.opener.postMessage({ token: access_token, expires: expireTime });
+  window.opener.postMessage({ token: access_token, expires: expireTime }, '*');
   window.close();
 }
 


### PR DESCRIPTION
This fixes the bug in Safari where Optimizely OAuth won't work due to `postMessage` not receiving a `targetOrigin`. I believe this worked on Chrome because Chrome automatically handles the situation.