### PR TITLE
Validate and save upon field change

### DIFF
--- a/samples/json-form-editor/index.html
+++ b/samples/json-form-editor/index.html
@@ -251,11 +251,16 @@
              disable_properties: true,
              show_errors: 'always'
          });
-         editor.on('change', inputChanged);
-
-         function inputChanged () {
+         
+         var watcherCallback = function(path) {
              cfApi.window.updateHeight();
              validateAndSave();
+         };
+  
+         for (var key in editor.editors) {
+             if (editor.editors.hasOwnProperty(key) && key !== 'root') {
+                 editor.watch(key, watcherCallback.bind(editor, key));
+             }
          }
 
          var validateAndSave = debounce(function () {


### PR DESCRIPTION
Validate and save upon field change as opposed to extension load.
This was disrupting my editorial team's workflow. 
After updating the schema, once the extension was in view then the entry status would change from publish to pending changes.
This proposed file change will only change the entry status upon a field being changed rather than the extension being loaded.