### PR TITLE
Default token option for Frontify app

### DIFF
--- a/marketplace/frontify-assets/extension.json
+++ b/marketplace/frontify-assets/extension.json
@@ -12,6 +12,13 @@
         "description": "Your Frontify domain, e.g. https://weare.frontify.com",
         "default": "https://weare.frontify.com",
         "required": true
+      },
+      {
+        "id": "defaultAccessToken",
+        "type": "Symbol",
+        "name": "Default Access Token",
+        "description": "Your Frontify access token to be used on all fields by default. Can be overridden in field configuration.",
+        "required": false
       }
     ],
     "instance": [
@@ -20,8 +27,7 @@
         "type": "Symbol",
         "name": "Access Token",
         "description": "Your Frontify access token",
-        "default": "",
-        "required": true
+        "required": false
       }
     ]
   }

--- a/marketplace/frontify-assets/src/index.js
+++ b/marketplace/frontify-assets/src/index.js
@@ -63,13 +63,22 @@ function renderDialog(sdk) {
   });
 }
 
-async function openDialog(sdk, _currentValue) {
+async function openDialog(sdk) {
+  const params = sdk.parameters;
+  // Use per-field access token first, if not provided then default to app config.
+  const accessToken = params.instance.accessToken || params.installation.defaultAccessToken;
+
+  if (typeof accessToken !== 'string' || accessToken.length < 1) {
+    sdk.notifier.error('No valid acccess token found. Update app or field configuration.');
+    return;
+  }
+
   const result = await sdk.dialogs.openExtension({
     position: 'center',
     title: CTA,
     shouldCloseOnOverlayClick: true,
     shouldCloseOnEscapePress: true,
-    parameters: { ...sdk.parameters.installation, ...sdk.parameters.instance },
+    parameters: { domain: params.installation.domain, accessToken },
     width: 1400
   });
 


### PR DESCRIPTION
In Frontify it sometimes makes sense to use separate keys per field to access different collections.

This PR adds the default option in app configuration that can be then overridden on the field level.

@brunschgi could you also please take a look?