### PR TITLE
Mux Video delete action

### DIFF
--- a/marketplace/mux-video-uploader/package-lock.json
+++ b/marketplace/mux-video-uploader/package-lock.json
@@ -5458,7 +5458,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5479,12 +5480,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5499,17 +5502,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5626,7 +5632,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5638,6 +5645,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5652,6 +5660,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5659,12 +5668,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5683,6 +5694,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5763,7 +5775,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5775,6 +5788,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5860,7 +5874,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5896,6 +5911,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5915,6 +5931,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5958,12 +5975,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -6138,9 +6157,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
-      "integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.2.tgz",
+      "integrity": "sha512-4PwqDL2laXtTWZghzzCtunQUTLbo31pcCJrd/B/9JP8XbhVzpS5ZXuKqlOzsd1rtcaLo4KqAn8nl8mkknS4MHw==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
@@ -6429,12 +6448,12 @@
       "dev": true
     },
     "https-proxy-agent": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
-      "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
+      "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
       "dev": true,
       "requires": {
-        "agent-base": "^4.1.0",
+        "agent-base": "^4.3.0",
         "debug": "^3.1.0"
       },
       "dependencies": {
@@ -8363,9 +8382,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
       "dev": true
     },
     "lodash._baseisequal": {
@@ -12613,9 +12632,9 @@
       }
     },
     "tree-kill": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.1.tgz",
-      "integrity": "sha512-4hjqbObwlh2dLyW4tcz0Ymw0ggoaVDMveUB9w8kFSQScdRLo0gxO9J7WFcUBo+W3C1TLdFIEwNOWebgZZ0RH9Q==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
       "dev": true
     },
     "trim-newlines": {
@@ -12745,16 +12764,23 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.0.tgz",
-      "integrity": "sha512-W+jrUHJr3DXKhrsS7NUVxn3zqMOFn0hL/Ei6v0anCIMoKC93TjcflTagwIHLW7SfMFfiQuktQyFVCFHGUE0+yg==",
+      "version": "3.7.6",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.7.6.tgz",
+      "integrity": "sha512-yYqjArOYSxvqeeiYH2VGjZOqq6SVmhxzaPjJC1W2F9e+bqvFL9QXQ2osQuKUFjM2hGjKG2YclQnRKWQSt/nOTQ==",
       "dev": true,
       "optional": true,
       "requires": {
-        "commander": "~2.20.0",
+        "commander": "~2.20.3",
         "source-map": "~0.6.1"
       },
       "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+          "dev": true,
+          "optional": true
+        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",

--- a/marketplace/mux-video-uploader/package.json
+++ b/marketplace/mux-video-uploader/package.json
@@ -51,7 +51,8 @@
     "help": "contentful-extension-scripts help",
     "tsc": "tsc -p ./ --noEmit",
     "test": "contentful-extension-scripts test --env=jsdom --watch",
-    "test:coverage": "contentful-extension-scripts test --env=jsdom --coverage"
+    "test:coverage": "contentful-extension-scripts test --env=jsdom --coverage",
+    "contentful": "contentful"
   },
   "prettier": {
     "trailingComma": "es5",

--- a/marketplace/mux-video-uploader/src/deleteButton.css
+++ b/marketplace/mux-video-uploader/src/deleteButton.css
@@ -1,0 +1,3 @@
+.button-container {
+  padding: 20px 0;
+}

--- a/marketplace/mux-video-uploader/src/deleteButton.tsx
+++ b/marketplace/mux-video-uploader/src/deleteButton.tsx
@@ -1,0 +1,21 @@
+/* eslint-disable jsx-a11y/media-has-caption */
+import * as React from 'react';
+import { Button } from '@contentful/forma-36-react-components';
+import './deleteButton.css';
+
+interface DeleteActionProps {
+  assetId: string;
+  requestDeleteAsset: ((assetId: string) => void);
+}
+
+class DeleteButton extends React.Component<DeleteActionProps, {}> {
+  render() {
+    return (
+      <div className='button-container'>
+        <Button buttonType='negative' size='small' onClick={() => this.props.requestDeleteAsset(this.props.assetId)}>Delete this asset</Button>
+      </div>
+    );
+  }
+}
+
+export default DeleteButton;

--- a/marketplace/mux-video-uploader/src/deleteButton.tsx
+++ b/marketplace/mux-video-uploader/src/deleteButton.tsx
@@ -4,15 +4,14 @@ import { Button } from '@contentful/forma-36-react-components';
 import './deleteButton.css';
 
 interface DeleteActionProps {
-  assetId: string;
-  requestDeleteAsset: ((assetId: string) => void);
+  requestDeleteAsset: (() => void);
 }
 
 class DeleteButton extends React.Component<DeleteActionProps, {}> {
   render() {
     return (
       <div className='button-container'>
-        <Button buttonType='negative' size='small' onClick={() => this.props.requestDeleteAsset(this.props.assetId)}>Delete this asset</Button>
+        <Button buttonType='negative' size='small' onClick={this.props.requestDeleteAsset}>Delete this asset</Button>
       </div>
     );
   }

--- a/marketplace/mux-video-uploader/src/index.css
+++ b/marketplace/mux-video-uploader/src/index.css
@@ -43,3 +43,7 @@ div {
   border-bottom-left-radius: 20px;
   overflow: hidden;
 }
+
+.reset-field-button {
+  margin-left: 10px;
+}

--- a/marketplace/mux-video-uploader/src/index.tsx
+++ b/marketplace/mux-video-uploader/src/index.tsx
@@ -125,7 +125,7 @@ export class App extends React.Component<AppProps, AppState> {
       message: "This will remove the asset in Mux and in Contentful. There is no way to recover your video, make sure you have a backup if you think you may want to use it again.",
       intent: "negative",
       confirmLabel: "Yes, delete this asset",
-      cancelLabel: "Nevermind",
+      cancelLabel: "Cancel",
     });
 
     if (!result) {

--- a/marketplace/mux-video-uploader/src/player.tsx
+++ b/marketplace/mux-video-uploader/src/player.tsx
@@ -57,9 +57,6 @@ class Player extends React.Component<PlayerProps, {}> {
 
   getHeight = () => {
     if (!this.playerRef.current) return;
-
-    console.log(this.playerRef.current.offsetWidth);
-
     return this.playerRef.current.offsetWidth * this.convertRatio();
   };
 


### PR DESCRIPTION
This request came from one of our users. This was a big usability shortcoming of our extension. Imagine the following scenario:

1. User creates a new piece of content in contentful that contains many fields, one of those fields is a Mux Video and the user uploads a video
1. Later, the user wants to replace the video with a different edited version.
1. There was no way to do that.

Now there is, this red "Delete asset" button below the mux video (with a confirmation dialog) will:

1. Send a DELETE request so the asset gets deleted in Mux's world
1. Set all the keys of the muxAsset JSON object to `undefined`

![contentful-delete-mux](https://user-images.githubusercontent.com/764988/73110470-60ad5480-3ebb-11ea-942a-b017409cc2dc.gif)

A few other things:

- [x] handle the case where contentful has a reference to a Mux asset but that Mux asset doesn't exist anymore (at any time a user can login to Mux and delete an asset from the dashboard) 
- [x] run `npm audit fix`

![deleted-asset_2020-01-24_15-46-43](https://user-images.githubusercontent.com/764988/73111875-e2ec4780-3ec0-11ea-8a58-a21a34fe3631.png)
