### PR TITLE
fixing setState linting error

### DIFF
--- a/marketplace/mux-video-uploader/src/index.tsx
+++ b/marketplace/mux-video-uploader/src/index.tsx
@@ -84,6 +84,7 @@ export class App extends React.Component<AppProps, AppState> {
       if (this.state.value.ready) {
         const asset = await this.getAsset();
         if (!asset) {
+          // eslint-disable-next-line react/no-did-mount-set-state
           this.setState({
             error: 'Error: it appears that this asset has been deleted',
             errorShowResetAction: true,


### PR DESCRIPTION
Lint doesn't recognize the `await` keyword and things this is a sync setState in mount.