### PR TITLE
Remove unused "settings" key from targetState in Focal Point

### DIFF
--- a/marketplace/image-focal-point/src/components/AppView/AppView.js
+++ b/marketplace/image-focal-point/src/components/AppView/AppView.js
@@ -117,14 +117,7 @@ export class AppView extends Component {
       targetState: {
         EditorInterface: {
           [contentType.sys.id]: {
-            controls: [
-              {
-                fieldId: 'focalPoint',
-                settings: {
-                  imageFieldId: 'image'
-                }
-              }
-            ]
+            controls: [{ fieldId: 'focalPoint' }]
           }
         }
       }


### PR DESCRIPTION
This is the only app that declares `settings` but they are not used. I'm going to remove them from the `targetState` DSL.