### PR TITLE
Add simple branch support for Netlify builds

### DIFF
--- a/marketplace/netlify-build/src/app/netlify-client.js
+++ b/marketplace/netlify-build/src/app/netlify-client.js
@@ -120,9 +120,10 @@ export async function listSites(accessToken) {
   };
 }
 
-export function createBuildHook(siteId, accessToken) {
+export function createBuildHook(siteId, accessToken, branch = null) {
   return post(`/sites/${siteId}/build_hooks`, accessToken, {
-    title: 'Contentful integration'
+    title: 'Contentful integration' + branch ? ` (${branch})` : '',
+    branch
   });
 }
 

--- a/marketplace/netlify-build/src/app/netlify-config-editor.js
+++ b/marketplace/netlify-build/src/app/netlify-config-editor.js
@@ -77,6 +77,14 @@ export default class NetlifyConfigEditor extends React.Component {
     onSiteConfigsChange(updated);
   };
 
+  onBranchChange = (configIndex, branch) => {
+    const { siteConfigs, onSiteConfigsChange } = this.props;
+    const updated = siteConfigs.map((siteConfig, i) => {
+      return configIndex === i ? { ...siteConfig, branch } : siteConfig;
+    });
+    onSiteConfigsChange(updated);
+  };
+
   onAdd = () => {
     const { siteConfigs, onSiteConfigsChange } = this.props;
     const updated = siteConfigs.concat([{}]);
@@ -106,6 +114,7 @@ export default class NetlifyConfigEditor extends React.Component {
         {siteConfigs.map((siteConfig, configIndex) => {
           const selectId = `site-select-${configIndex}`;
           const inputId = `site-input-${configIndex}`;
+          const branchInputId = `site-branch-input-${configIndex}`;
           return (
             <div key={configIndex} className={styles.row}>
               <SelectField
@@ -134,6 +143,15 @@ export default class NetlifyConfigEditor extends React.Component {
                 value={siteConfig.name || ''}
                 onChange={e => this.onNameChange(configIndex, e.target.value)}
               />
+              <TextField
+                className={styles.item}
+                id={branchInputId}
+                name={branchInputId}
+                labelText="Branch (optional):"
+                textInputProps={{ disabled, width: 'small', maxLength: 50 }}
+                value={siteConfig.branch || ''}
+                onChange={e => this.onBranchChange(configIndex, e.target.value)}
+                />
               <TextLink
                 className={styles.removeBtn}
                 disabled={disabled}

--- a/marketplace/netlify-build/src/app/netlify-integration.js
+++ b/marketplace/netlify-build/src/app/netlify-integration.js
@@ -15,7 +15,7 @@ export async function install({ config, accessToken }) {
 
   // Create build hooks for all sites.
   const buildHookPromises = config.sites.map(siteConfig => {
-    return NetlifyClient.createBuildHook(siteConfig.netlifySiteId, accessToken);
+    return NetlifyClient.createBuildHook(siteConfig.netlifySiteId, accessToken, siteConfig.branch);
   });
 
   const buildHooks = await Promise.all(buildHookPromises);


### PR DESCRIPTION
It it's circumstantial and unnecessary to create different Netlify sites to build and deploy different branches (e.g. staging and production).

This PR adds an input field for the branch (no auto completion) and passes this branch to the build hook creation.

Please note that this change is untested because I have no access to the early access programm yet. But in any case it can be an inspiration for extending the existing plugin.