### PR TITLE
Updates to Gatsby Preview readme.

### DIFF
--- a/marketplace/gatsby-preview/README.md
+++ b/marketplace/gatsby-preview/README.md
@@ -1,6 +1,6 @@
-# Gatsby Preview
+# Gatsby Cloud
 
-Gatsby is an open-source, modern website framework based on React to create and deploy websites or web apps with ease. This UI Extension connects to [Gatsby Preview](https://www.gatsbyjs.com/cloud/) which lets you see updates to your Gatsby site as soon as you change content in Contentful. This makes it easy for content creators to see changes they make to the website before going live.
+Gatsby is an open-source, modern website framework based on React to create and deploy websites or web apps with ease. This UI Extension connects to [Gatsby Cloud](https://www.gatsbyjs.com/cloud/) which lets you see updates to your Gatsby site as soon as you change content in Contentful. This makes it easy for content creators to see changes they make to the website before going live.
 
 ![Demo of the extension](./assets/demo.gif)
 

--- a/marketplace/gatsby-preview/README.md
+++ b/marketplace/gatsby-preview/README.md
@@ -1,8 +1,6 @@
 # Gatsby Preview
 
-Gatsby is an open-source, modern website framework based on React to create and deploy websites or web apps with ease. This UI Extension connects to [Gatsby Preview](https://www.gatsbyjs.com/preview/) which lets you see updates to your Gatsby site as soon as you change content in Contentful. This makes it easy for content creators to see changes they make to the website before going live.
-
-**Note:** Gatsby Preview is still in beta, please be mindful when using this extension.
+Gatsby is an open-source, modern website framework based on React to create and deploy websites or web apps with ease. This UI Extension connects to [Gatsby Preview](https://www.gatsbyjs.com/cloud/) which lets you see updates to your Gatsby site as soon as you change content in Contentful. This makes it easy for content creators to see changes they make to the website before going live.
 
 ![Demo of the extension](./assets/demo.gif)
 
@@ -28,7 +26,7 @@ The extension has the following spec:
 
 In order to use this extension, you need:
 
-- a [Gatbsy Preview](https://www.gatsbyjs.com/preview/) setup to use this extension
+- a [Gatbsy Cloud](https://www.gatsbyjs.com/cloud/) setup to use this extension
 - a space and the Contentful CLI installed
 
 ## Usage

--- a/samples/gatsby-preview/README.md
+++ b/samples/gatsby-preview/README.md
@@ -1,8 +1,6 @@
 # Gatsby Cloud
 
-Gatsby is an open-source, modern website framework based on React to create and deploy websites or web apps with ease. This UI Extension connects to [Gatsby Cloud](https://www.gatsbyjs.com/preview/) which lets you see updates to your Gatsby site as soon as you change content in Contentful. This makes it easy for content creators to see changes they make to the website before going live.
-
-**Note:** Gatsby Cloud is still in beta, please be mindful when using this extension.
+Gatsby is an open-source, modern website framework based on React to create and deploy websites or web apps with ease. This UI Extension connects to [Gatsby Cloud](https://www.gatsbyjs.com/cloud/) which lets you see updates to your Gatsby site as soon as you change content in Contentful. This makes it easy for content creators to see changes they make to the website before going live.
 
 ![Demo of the extension](demo.gif)
 
@@ -28,7 +26,7 @@ The extension has the following spec:
 
 In order to use this extension, you need:
 
-- a [Gatbsy Cloud](https://www.gatsbyjs.com/preview/) setup to use this extension
+- a [Gatbsy Cloud](https://www.gatsbyjs.com/cloud/) setup to use this extension
 - a space and the Contentful CLI installed
 
 ## Usage


### PR DESCRIPTION
Removes the "beta" warning from the readme and updates URLs to point to www.gatsbyjs.com/cloud instead of /preview.